### PR TITLE
Handle SP and IDP metadata when there are multiple role descriptors

### DIFF
--- a/components/org.wso2.carbon.identity.idp.metadata.saml2/src/main/java/org/wso2/carbon/identity/idp/metadata/saml2/util/SAML2SSOFederatedAuthenticatorConfigBuilder.java
+++ b/components/org.wso2.carbon.identity.idp.metadata.saml2/src/main/java/org/wso2/carbon/identity/idp/metadata/saml2/util/SAML2SSOFederatedAuthenticatorConfigBuilder.java
@@ -62,17 +62,35 @@ public class SAML2SSOFederatedAuthenticatorConfigBuilder {
 
         if (entityDescriptor != null) {
             List<RoleDescriptor> roleDescriptors = entityDescriptor.getRoleDescriptors();
-            //assuming only one IDPSSO is inside the entitydescripter
+            // Assuming only one IDPSSODescriptor is inside the EntityDescriptor.
             if (CollectionUtils.isNotEmpty(roleDescriptors)) {
-                RoleDescriptor roleDescriptor = roleDescriptors.get(0);
-                if (roleDescriptor != null) {
-                    IDPSSODescriptor idpssoDescriptor;
-                    try {
-                        idpssoDescriptor = (IDPSSODescriptor) roleDescriptor;
-                    } catch (ClassCastException ex) {
-                        throw new IdentityApplicationManagementException("No IDP Descriptors found, invalid file content", ex);
+                RoleDescriptor roleDescriptor = null;
+                if (roleDescriptors.size() > 1) {
+                    for (RoleDescriptor roleDescriptorElement : roleDescriptors) {
+                        if (roleDescriptorElement instanceof IDPSSODescriptor) {
+                            roleDescriptor = roleDescriptorElement;
+                            break;
+                        }
                     }
-                    Property properties[] = new Property[24];
+                    if (roleDescriptor == null) {
+                        throw new IdentityApplicationManagementException(
+                                "No IDP Descriptors found, invalid file content."
+                        );
+                    }
+                } else if (roleDescriptors.size() == 1) {
+                    if (roleDescriptors.get(0) instanceof IDPSSODescriptor) {
+                        roleDescriptor = roleDescriptors.get(0);
+                    } else {
+                        throw new IdentityApplicationManagementException(
+                                "No IDP Descriptors found, invalid file content."
+                        );
+                    }
+                } else {
+                    throw new IdentityApplicationManagementException("No IDP Descriptors found, invalid file content.");
+                }
+                if (roleDescriptor != null) {
+                    IDPSSODescriptor idpssoDescriptor = (IDPSSODescriptor) roleDescriptor;
+                    Property[] properties = new Property[24];
 
                     Property property = new Property();
                     property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.IDP_ENTITY_ID);

--- a/components/org.wso2.carbon.identity.idp.metadata.saml2/src/main/java/org/wso2/carbon/identity/idp/metadata/saml2/util/SAML2SSOFederatedAuthenticatorConfigBuilder.java
+++ b/components/org.wso2.carbon.identity.idp.metadata.saml2/src/main/java/org/wso2/carbon/identity/idp/metadata/saml2/util/SAML2SSOFederatedAuthenticatorConfigBuilder.java
@@ -83,26 +83,16 @@ public class SAML2SSOFederatedAuthenticatorConfigBuilder {
             // Assuming that only one IDPSSODescriptor is inside the EntityDescriptor.
             if (CollectionUtils.isNotEmpty(roleDescriptors)) {
                 IDPSSODescriptor idpssoDescriptor = null;
-                if (roleDescriptors.size() > 1) {
-                    for (RoleDescriptor roleDescriptor : roleDescriptors) {
-                        if (roleDescriptor instanceof IDPSSODescriptor) {
-                            idpssoDescriptor = (IDPSSODescriptor) roleDescriptor;
-                            break;
-                        }
+                for (RoleDescriptor roleDescriptor : roleDescriptors) {
+                    if (roleDescriptor instanceof IDPSSODescriptor) {
+                        idpssoDescriptor = (IDPSSODescriptor) roleDescriptor;
+                        break;
                     }
-                    if (idpssoDescriptor == null) {
-                        throw new IdentityApplicationManagementException(
-                                "No IDP Descriptors found, invalid file content."
-                        );
-                    }
-                } else {
-                    if (roleDescriptors.get(0) instanceof IDPSSODescriptor) {
-                        idpssoDescriptor = (IDPSSODescriptor) roleDescriptors.get(0);
-                    } else {
-                        throw new IdentityApplicationManagementException(
-                                "No IDP Descriptors found, invalid file content."
-                        );
-                    }
+                }
+                if (idpssoDescriptor == null) {
+                    throw new IdentityApplicationManagementException(
+                            "No IDP Descriptors found, invalid file content."
+                    );
                 }
 
                 Property[] properties = new Property[24];

--- a/components/org.wso2.carbon.identity.idp.metadata.saml2/src/main/java/org/wso2/carbon/identity/idp/metadata/saml2/util/SAML2SSOFederatedAuthenticatorConfigBuilder.java
+++ b/components/org.wso2.carbon.identity.idp.metadata.saml2/src/main/java/org/wso2/carbon/identity/idp/metadata/saml2/util/SAML2SSOFederatedAuthenticatorConfigBuilder.java
@@ -127,8 +127,7 @@ public class SAML2SSOFederatedAuthenticatorConfigBuilder {
                 List<SingleSignOnService> singleSignOnServices = idpssoDescriptor.getSingleSignOnServices();
                 if (CollectionUtils.isNotEmpty(singleSignOnServices)) {
                     boolean found = false;
-                    for (int j = 0; j < singleSignOnServices.size(); j++) {
-                        SingleSignOnService singleSignOnService = singleSignOnServices.get(j);
+                    for (SingleSignOnService singleSignOnService : singleSignOnServices) {
                         if (singleSignOnService != null) {
                             if (singleSignOnService.getLocation() != null) {
                                 property.setValue(singleSignOnService.getLocation());

--- a/components/org.wso2.carbon.identity.idp.metadata.saml2/src/main/java/org/wso2/carbon/identity/idp/metadata/saml2/util/SAML2SSOFederatedAuthenticatorConfigBuilder.java
+++ b/components/org.wso2.carbon.identity.idp.metadata.saml2/src/main/java/org/wso2/carbon/identity/idp/metadata/saml2/util/SAML2SSOFederatedAuthenticatorConfigBuilder.java
@@ -1,18 +1,38 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.identity.idp.metadata.saml2.util;
 
+import net.shibboleth.utilities.java.support.xml.XMLParserException;
 import org.apache.axiom.om.OMElement;
 import org.apache.commons.collections.CollectionUtils;
-import org.opensaml.saml.common.xml.SAMLConstants;
-import org.opensaml.saml.saml2.metadata.EntityDescriptor;
-import org.opensaml.saml.saml2.metadata.RoleDescriptor;
-import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
-import org.opensaml.saml.saml2.metadata.SingleSignOnService;
-import org.opensaml.saml.saml2.metadata.SingleLogoutService;
-import org.opensaml.saml.saml2.metadata.KeyDescriptor;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
 import org.opensaml.core.xml.io.UnmarshallingException;
 import org.opensaml.core.xml.util.XMLObjectSupport;
-import net.shibboleth.utilities.java.support.xml.XMLParserException;
+import org.opensaml.saml.common.xml.SAMLConstants;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
+import org.opensaml.saml.saml2.metadata.KeyDescriptor;
+import org.opensaml.saml.saml2.metadata.RoleDescriptor;
+import org.opensaml.saml.saml2.metadata.SingleLogoutService;
+import org.opensaml.saml.saml2.metadata.SingleSignOnService;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.Property;
@@ -21,11 +41,9 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
 /**
- * This class provides functionality to convert metadata String to federatedAuthenticatedConfig
+ * This class provides functionality to convert metadata String to federatedAuthenticatedConfig.
  */
 public class SAML2SSOFederatedAuthenticatorConfigBuilder {
     private static final Log log = LogFactory.getLog(SAML2SSOFederatedAuthenticatorConfigBuilder.class);
@@ -33,7 +51,7 @@ public class SAML2SSOFederatedAuthenticatorConfigBuilder {
     private static final String ENCRYPTION = "ENCRYPTION";
 
     /**
-     * Convert metadata String to entityDescriptor
+     * Convert metadata String to entityDescriptor.
      *
      * @param metadataString
      * @return EntityDescriptor
@@ -53,7 +71,7 @@ public class SAML2SSOFederatedAuthenticatorConfigBuilder {
     }
 
     /**
-     * Set the values of SamlSSOFederatedAuthenticationConfig from entitydescriptor
+     * Set the values of SamlSSOFederatedAuthenticationConfig from entitydescriptor.
      *
      * @param entityDescriptor ,federatedAuthenticatorConfig,builder
      * @return FederatedAuthenticatorConfig
@@ -62,278 +80,272 @@ public class SAML2SSOFederatedAuthenticatorConfigBuilder {
 
         if (entityDescriptor != null) {
             List<RoleDescriptor> roleDescriptors = entityDescriptor.getRoleDescriptors();
-            // Assuming only one IDPSSODescriptor is inside the EntityDescriptor.
+            // Assuming that only one IDPSSODescriptor is inside the EntityDescriptor.
             if (CollectionUtils.isNotEmpty(roleDescriptors)) {
-                RoleDescriptor roleDescriptor = null;
+                IDPSSODescriptor idpssoDescriptor = null;
                 if (roleDescriptors.size() > 1) {
-                    for (RoleDescriptor roleDescriptorElement : roleDescriptors) {
-                        if (roleDescriptorElement instanceof IDPSSODescriptor) {
-                            roleDescriptor = roleDescriptorElement;
+                    for (RoleDescriptor roleDescriptor : roleDescriptors) {
+                        if (roleDescriptor instanceof IDPSSODescriptor) {
+                            idpssoDescriptor = (IDPSSODescriptor) roleDescriptor;
                             break;
                         }
                     }
-                    if (roleDescriptor == null) {
-                        throw new IdentityApplicationManagementException(
-                                "No IDP Descriptors found, invalid file content."
-                        );
-                    }
-                } else if (roleDescriptors.size() == 1) {
-                    if (roleDescriptors.get(0) instanceof IDPSSODescriptor) {
-                        roleDescriptor = roleDescriptors.get(0);
-                    } else {
+                    if (idpssoDescriptor == null) {
                         throw new IdentityApplicationManagementException(
                                 "No IDP Descriptors found, invalid file content."
                         );
                     }
                 } else {
-                    throw new IdentityApplicationManagementException("No IDP Descriptors found, invalid file content.");
-                }
-                if (roleDescriptor != null) {
-                    IDPSSODescriptor idpssoDescriptor = (IDPSSODescriptor) roleDescriptor;
-                    Property[] properties = new Property[24];
-
-                    Property property = new Property();
-                    property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.IDP_ENTITY_ID);
-                    if (entityDescriptor.getEntityID() != null && entityDescriptor.getEntityID().length()>0) {
-                        property.setValue(entityDescriptor.getEntityID());
+                    if (roleDescriptors.get(0) instanceof IDPSSODescriptor) {
+                        idpssoDescriptor = (IDPSSODescriptor) roleDescriptors.get(0);
                     } else {
-                        property.setValue("");
-                        throw new IdentityApplicationManagementException("No Entity ID found, invalid file content");
+                        throw new IdentityApplicationManagementException(
+                                "No IDP Descriptors found, invalid file content."
+                        );
                     }
-                    properties[0] = property;
+                }
 
-                    property = new Property();
-                    property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.SP_ENTITY_ID);
-                    property.setValue("");//not available in the metadata specification
-                    properties[1] = property;
+                Property[] properties = new Property[24];
 
-                    property = new Property();
-                    property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.SSO_URL);
-                    List<SingleSignOnService> singleSignOnServices = idpssoDescriptor.getSingleSignOnServices();
-                    if (CollectionUtils.isNotEmpty(singleSignOnServices)) {
-                        boolean found = false;
-                        for (int j = 0; j < singleSignOnServices.size(); j++) {
-                            SingleSignOnService singleSignOnService = singleSignOnServices.get(j);
-                            if (singleSignOnService != null) {
-                                if (singleSignOnService.getLocation() != null) {
-                                    property.setValue(singleSignOnService.getLocation());
-                                    found = true;
-                                    break;
-                                }
+                Property property = new Property();
+                property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.IDP_ENTITY_ID);
+                if (entityDescriptor.getEntityID() != null && entityDescriptor.getEntityID().length() > 0) {
+                    property.setValue(entityDescriptor.getEntityID());
+                } else {
+                    property.setValue("");
+                    throw new IdentityApplicationManagementException("No Entity ID found, invalid file content");
+                }
+                properties[0] = property;
+
+                property = new Property();
+                property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.SP_ENTITY_ID);
+                property.setValue(""); // Not available in the metadata specification.
+                properties[1] = property;
+
+                property = new Property();
+                property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.SSO_URL);
+                List<SingleSignOnService> singleSignOnServices = idpssoDescriptor.getSingleSignOnServices();
+                if (CollectionUtils.isNotEmpty(singleSignOnServices)) {
+                    boolean found = false;
+                    for (int j = 0; j < singleSignOnServices.size(); j++) {
+                        SingleSignOnService singleSignOnService = singleSignOnServices.get(j);
+                        if (singleSignOnService != null) {
+                            if (singleSignOnService.getLocation() != null) {
+                                property.setValue(singleSignOnService.getLocation());
+                                found = true;
+                                break;
                             }
                         }
-                        if (!found) {
-                            property.setValue("");
-                            throw new IdentityApplicationManagementException("No SSO URL, invalid file content");
-                        }
-                    } else {
+                    }
+                    if (!found) {
                         property.setValue("");
                         throw new IdentityApplicationManagementException("No SSO URL, invalid file content");
                     }
-                    properties[2] = property;
+                } else {
+                    property.setValue("");
+                    throw new IdentityApplicationManagementException("No SSO URL, invalid file content");
+                }
+                properties[2] = property;
 
-                    property = new Property();
-                    property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.IS_AUTHN_REQ_SIGNED);
-                    if (idpssoDescriptor.getWantAuthnRequestsSigned() != null && idpssoDescriptor.getWantAuthnRequestsSigned() == true) {
-                        property.setValue("true");
-                    } else {
-                        property.setValue("false");
+                property = new Property();
+                property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.IS_AUTHN_REQ_SIGNED);
+                if (idpssoDescriptor.getWantAuthnRequestsSigned() != null && idpssoDescriptor.getWantAuthnRequestsSigned()) {
+                    property.setValue("true");
+                } else {
+                    property.setValue("false");
+                }
+                properties[3] = property;
+
+                property = new Property();
+                property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.IS_LOGOUT_ENABLED);
+                List<SingleLogoutService> singleLogoutServices = idpssoDescriptor.getSingleLogoutServices();
+                if (CollectionUtils.isNotEmpty(singleLogoutServices)) {
+                    property.setValue("true");
+                } else {
+                    property.setValue("false");
+                }
+                properties[4] = property;
+
+                property = new Property();
+                property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.LOGOUT_REQ_URL);
+                if (CollectionUtils.isNotEmpty(singleLogoutServices)) {
+                    boolean foundSingleLogoutServicePostBinding = false;
+                    for (SingleLogoutService singleLogoutService : singleLogoutServices) {
+                        if (singleLogoutService != null) {
+                            if (singleLogoutService.getBinding() != null && singleLogoutService.getBinding().equals(SAMLConstants.SAML2_POST_BINDING_URI) && singleLogoutService.getLocation() != null) {
+                                property.setValue(singleLogoutService.getLocation());
+                                foundSingleLogoutServicePostBinding = true;
+                                break;
+                            }
+                        }
                     }
-                    properties[3] = property;
-
-                    property = new Property();
-                    property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.IS_LOGOUT_ENABLED);
-                    List<SingleLogoutService> singleLogoutServices = idpssoDescriptor.getSingleLogoutServices();
-                    if (CollectionUtils.isNotEmpty(singleLogoutServices)) {
-                        property.setValue("true");
-                    } else {
-                        property.setValue("false");
-                    }
-                    properties[4] = property;
-
-                    property = new Property();
-                    property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.LOGOUT_REQ_URL);
-                    if (CollectionUtils.isNotEmpty(singleLogoutServices)) {
-                        boolean foundSingleLogoutServicePostBinding = false;
+                    if (!foundSingleLogoutServicePostBinding) {
                         for (SingleLogoutService singleLogoutService : singleLogoutServices) {
                             if (singleLogoutService != null) {
-                                if (singleLogoutService.getBinding() != null && singleLogoutService.getBinding().equals(SAMLConstants.SAML2_POST_BINDING_URI) && singleLogoutService.getLocation() != null) {
+                                if (singleLogoutService.getBinding() != null && singleLogoutService.getLocation() != null) {
                                     property.setValue(singleLogoutService.getLocation());
                                     foundSingleLogoutServicePostBinding = true;
                                     break;
                                 }
                             }
                         }
-                        if (!foundSingleLogoutServicePostBinding) {
-                            for (SingleLogoutService singleLogoutService : singleLogoutServices) {
-                                if (singleLogoutService != null) {
-                                    if (singleLogoutService.getBinding() != null && singleLogoutService.getLocation() != null) {
-                                        property.setValue(singleLogoutService.getLocation());
-                                        foundSingleLogoutServicePostBinding = true;
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                        if (!foundSingleLogoutServicePostBinding) {
-                            property.setValue("");
-                        }
-                    } else {
+                    }
+                    if (!foundSingleLogoutServicePostBinding) {
                         property.setValue("");
                     }
-                    properties[5] = property;
+                } else {
+                    property.setValue("");
+                }
+                properties[5] = property;
 
-                    property = new Property();
-                    property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.IS_LOGOUT_REQ_SIGNED);
-                    property.setValue("");//not found in the metadata spec
-                    //Not found in the Metadata Spec
-                    properties[6] = property;
+                property = new Property();
+                property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.IS_LOGOUT_REQ_SIGNED);
+                property.setValue(""); // Not found in the metadata spec.
+                //Not found in the Metadata Spec
+                properties[6] = property;
 
-                    property = new Property();
-                    property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.IS_AUTHN_RESP_SIGNED);
-                    property.setValue("");//not found in the metadata spec
-                    properties[7] = property;
+                property = new Property();
+                property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.IS_AUTHN_RESP_SIGNED);
+                property.setValue(""); // Not found in the metadata spec.
+                properties[7] = property;
 
-                    property = new Property();
-                    property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.IS_USER_ID_IN_CLAIMS);
-                    property.setValue("");//not found in the metadata spec
-                    properties[8] = property;
+                property = new Property();
+                property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.IS_USER_ID_IN_CLAIMS);
+                property.setValue(""); // Not found in the metadata spec.
+                properties[8] = property;
 
-                    property = new Property();
-                    property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.IS_ENABLE_ASSERTION_ENCRYPTION);
-                    property.setValue("");//not found in the metadata spec
-                    properties[9] = property;
+                property = new Property();
+                property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.IS_ENABLE_ASSERTION_ENCRYPTION);
+                property.setValue(""); // Not found in the metadata spec.
+                properties[9] = property;
 
-                    property = new Property();
-                    property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.IS_ENABLE_ASSERTION_SIGNING);
-                    property.setValue("");///not found in the metadata spec
-                    properties[10] = property;
+                property = new Property();
+                property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.IS_ENABLE_ASSERTION_SIGNING);
+                property.setValue(""); // Not found in the metadata spec.
+                properties[10] = property;
 
-                    List<KeyDescriptor> descriptors = idpssoDescriptor.getKeyDescriptors();
-                    if (CollectionUtils.isNotEmpty(descriptors)) {
-                        for (int i = 0; i < descriptors.size(); i++) {
-                            KeyDescriptor descriptor = descriptors.get(i);
-                            if (descriptor != null) {
-                                String use = "";
-                                try {
-                                    use = descriptor.getUse().name().toString();
-                                } catch (Exception ex) {
-                                    log.error("Error !!!!", ex);
-                                }
-                                if (SIGNING.equals(use)) {
-                                    properties[10].setValue("true");
-                                } else if (ENCRYPTION.equals(use)) {
-                                    properties[9].setValue("true");
-                                }
+                List<KeyDescriptor> descriptors = idpssoDescriptor.getKeyDescriptors();
+                if (CollectionUtils.isNotEmpty(descriptors)) {
+                    for (KeyDescriptor descriptor : descriptors) {
+                        if (descriptor != null) {
+                            String use = "";
+                            try {
+                                use = descriptor.getUse().name();
+                            } catch (Exception ex) {
+                                log.error("Error !!!!", ex);
+                            }
+                            if (SIGNING.equals(use)) {
+                                properties[10].setValue("true");
+                            } else if (ENCRYPTION.equals(use)) {
+                                properties[9].setValue("true");
                             }
                         }
                     }
+                }
 
-                    property = new Property();
-                    property.setName("commonAuthQueryParams");//SAML querry param in the gui
-                    property.setValue("");//not found in the metadata spec
-                    properties[11] = property;
+                property = new Property();
+                property.setName("commonAuthQueryParams"); //S AML query param in the GUI.
+                property.setValue(""); // Not found in the metadata spec.
+                properties[11] = property;
 
-                    property = new Property();
-                    property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.REQUEST_METHOD);
-                    property.setValue("");//not found in the metadata spec
-                    properties[12] = property;
+                property = new Property();
+                property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.REQUEST_METHOD);
+                property.setValue(""); // Not found in the metadata spec.
+                properties[12] = property;
 
-                    property = new Property();
-                    property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.SIGNATURE_ALGORITHM);
-                    property.setValue("");//not found in the metadata spec
-                    properties[13] = property;
+                property = new Property();
+                property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.SIGNATURE_ALGORITHM);
+                property.setValue(""); // Not found in the metadata spec.
+                properties[13] = property;
 
-                    property = new Property();
-                    property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.DIGEST_ALGORITHM);
-                    property.setValue("");//not found in the metadata spec
-                    properties[14] = property;
+                property = new Property();
+                property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.DIGEST_ALGORITHM);
+                property.setValue(""); // Not found in the metadata spec.
+                properties[14] = property;
 
-                    property = new Property();
-                    property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.AUTHENTICATION_CONTEXT_COMPARISON_LEVEL);
-                    property.setValue("");//not found in the metadata spec
-                    properties[15] = property;
+                property = new Property();
+                property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.AUTHENTICATION_CONTEXT_COMPARISON_LEVEL);
+                property.setValue(""); // Not found in the metadata spec.
+                properties[15] = property;
 
-                    property = new Property();
-                    property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.INCLUDE_NAME_ID_POLICY);
-                    property.setValue("");//not found in the metadata spec
-                    properties[16] = property;
+                property = new Property();
+                property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.INCLUDE_NAME_ID_POLICY);
+                property.setValue(""); // Not found in the metadata spec.
+                properties[16] = property;
 
-                    property = new Property();
-                    property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.FORCE_AUTHENTICATION);
-                    property.setValue("");//not found in the metadata spec
-                    properties[17] = property;
+                property = new Property();
+                property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.FORCE_AUTHENTICATION);
+                property.setValue(""); // Not found in the metadata spec.
+                properties[17] = property;
 
-                    property = new Property();
-                    property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.SIGNATURE_ALGORITHM_POST);
-                    property.setValue("");//not found in the metadata spec
-                    properties[18] = property;
+                property = new Property();
+                property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.SIGNATURE_ALGORITHM_POST);
+                property.setValue(""); // Not found in the metadata spec.
+                properties[18] = property;
 
-                    property = new Property();
-                    property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.AUTHENTICATION_CONTEXT_CLASS);
-                    property.setValue("");//not found in the metadata spec
-                    properties[19] = property;
+                property = new Property();
+                property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.AUTHENTICATION_CONTEXT_CLASS);
+                property.setValue(""); // Not found in the metadata spec.
+                properties[19] = property;
 
-                    property = new Property();
-                    property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.ATTRIBUTE_CONSUMING_SERVICE_INDEX);
-                    property.setValue("");//not found in the metadata spec
-                    properties[20] = property;
+                property = new Property();
+                property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.ATTRIBUTE_CONSUMING_SERVICE_INDEX);
+                property.setValue(""); // Not found in the metadata spec.
+                properties[20] = property;
 
-                    property = new Property();
-                    property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.INCLUDE_CERT);
-                    property.setValue("");//not found in the metadata spec
-                    properties[21] = property;
+                property = new Property();
+                property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.INCLUDE_CERT);
+                property.setValue(""); // Not found in the metadata spec.
+                properties[21] = property;
 
-                    property = new Property();
-                    property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.INCLUDE_AUTHN_CONTEXT);
-                    property.setValue("");//not found in the metadata spec
-                    properties[22] = property;
+                property = new Property();
+                property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.INCLUDE_AUTHN_CONTEXT);
+                property.setValue(""); // Not found in the metadata spec.
+                properties[22] = property;
 
-                    property = new Property();
-                    property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.INCLUDE_PROTOCOL_BINDING);
-                    property.setValue("");//not found in the metadata spec
-                    properties[23] = property;
+                property = new Property();
+                property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.INCLUDE_PROTOCOL_BINDING);
+                property.setValue(""); // Not found in the metadata spec.
+                properties[23] = property;
 
-                    federatedAuthenticatorConfig.setProperties(properties);
+                federatedAuthenticatorConfig.setProperties(properties);
 
-                    //set certificates
-                    if (CollectionUtils.isNotEmpty(descriptors)) {
-                        for (int i = 0; i < descriptors.size(); i++) {
-                            KeyDescriptor descriptor = descriptors.get(i);
-                            if (descriptor != null) {
-                                if (descriptor.getUse() != null && "SIGNING".equals(descriptor.getUse().toString())) {
-                                    try {
-                                        String cert = null;
-                                        if (descriptor.getKeyInfo() != null) {
-                                            if (descriptor.getKeyInfo().getX509Datas() != null && descriptor.getKeyInfo().getX509Datas().size() > 0) {
-                                                for (int k = 0; k < descriptor.getKeyInfo().getX509Datas().size(); k++) {
-                                                    if (descriptor.getKeyInfo().getX509Datas().get(k) != null) {
-                                                        if (descriptor.getKeyInfo().getX509Datas().get(k).getX509Certificates() != null &&
-                                                                descriptor.getKeyInfo().getX509Datas().get(0).getX509Certificates().size() > 0) {
-                                                            for (int y = 0; y < descriptor.getKeyInfo().getX509Datas().get(k).getX509Certificates().size(); y++) {
-                                                                if (descriptor.getKeyInfo().getX509Datas().get(k).getX509Certificates().get(y) != null) {
-                                                                    if (descriptor.getKeyInfo().getX509Datas().get(k).getX509Certificates().get(y).
-                                                                            getValue() != null && descriptor.getKeyInfo().getX509Datas().get(k).getX509Certificates().
-                                                                            get(y).getValue().length() > 0) {
+                // Set certificates.
+                if (CollectionUtils.isNotEmpty(descriptors)) {
+                    for (KeyDescriptor descriptor : descriptors) {
+                        if (descriptor != null) {
+                            if (descriptor.getUse() != null && "SIGNING".equals(descriptor.getUse().toString())) {
+                                try {
+                                    String cert;
+                                    if (descriptor.getKeyInfo() != null) {
+                                        if (descriptor.getKeyInfo().getX509Datas() != null && descriptor.getKeyInfo().getX509Datas().size() > 0) {
+                                            for (int k = 0; k < descriptor.getKeyInfo().getX509Datas().size(); k++) {
+                                                if (descriptor.getKeyInfo().getX509Datas().get(k) != null) {
+                                                    if (descriptor.getKeyInfo().getX509Datas().get(k).getX509Certificates() != null &&
+                                                            descriptor.getKeyInfo().getX509Datas().get(0).getX509Certificates().size() > 0) {
+                                                        for (int y = 0; y < descriptor.getKeyInfo().getX509Datas().get(k).getX509Certificates().size(); y++) {
+                                                            if (descriptor.getKeyInfo().getX509Datas().get(k).getX509Certificates().get(y) != null) {
+                                                                if (descriptor.getKeyInfo().getX509Datas().get(k).getX509Certificates().get(y).
+                                                                        getValue() != null && descriptor.getKeyInfo().getX509Datas().get(k).getX509Certificates().
+                                                                        get(y).getValue().length() > 0) {
 
-                                                                        cert = descriptor.getKeyInfo().getX509Datas().get(k).getX509Certificates().get(y).
-                                                                                getValue().toString();
+                                                                    cert = descriptor.getKeyInfo().getX509Datas().get(k).getX509Certificates().get(y).
+                                                                            getValue();
 
-                                                                        builder.append(org.apache.axiom.om.util.Base64.encode(cert.getBytes()));
-                                                                        return federatedAuthenticatorConfig;
-                                                                    }
+                                                                    builder.append(org.apache.axiom.om.util.Base64.encode(cert.getBytes()));
+                                                                    return federatedAuthenticatorConfig;
                                                                 }
                                                             }
                                                         }
-
                                                     }
+
                                                 }
                                             }
                                         }
-                                    } catch (java.lang.Exception ex) {
-                                        log.error("Error While setting Certificate", ex);
-                                        break;
                                     }
+                                } catch (Exception ex) {
+                                    log.error("Error While setting Certificate", ex);
+                                    break;
                                 }
                             }
                         }
@@ -347,7 +359,7 @@ public class SAML2SSOFederatedAuthenticatorConfigBuilder {
     }
 
     /**
-     * Convert metadata OMElement to FederatedAuthenticatorConfigobject
+     * Convert metadata OMElement to FederatedAuthenticatorConfigobject.
      *
      * @param saml2FederatedAuthenticatorConfigOM ,builder
      * @return FederatedAuthenticatorConfig

--- a/components/org.wso2.carbon.identity.sp.metadata.saml2/src/main/java/org/wso2/carbon/identity/sp/metadata/saml2/util/Parser.java
+++ b/components/org.wso2.carbon.identity.sp.metadata.saml2/src/main/java/org/wso2/carbon/identity/sp/metadata/saml2/util/Parser.java
@@ -15,19 +15,27 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.wso2.carbon.identity.sp.metadata.saml2.util;
 
+import net.shibboleth.utilities.java.support.xml.XMLParserException;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.opensaml.saml.common.xml.SAMLConstants;
-import org.opensaml.saml.saml2.metadata.*;
+import org.opensaml.core.config.InitializationException;
 import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
 import org.opensaml.core.xml.io.UnmarshallingException;
 import org.opensaml.core.xml.util.XMLObjectSupport;
-import org.opensaml.core.config.InitializationException;
-import net.shibboleth.utilities.java.support.xml.XMLParserException;
-import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.opensaml.saml.common.xml.SAMLConstants;
+import org.opensaml.saml.saml2.metadata.AssertionConsumerService;
+import org.opensaml.saml.saml2.metadata.AttributeConsumingService;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.saml.saml2.metadata.KeyDescriptor;
+import org.opensaml.saml.saml2.metadata.NameIDFormat;
+import org.opensaml.saml.saml2.metadata.RequestedAttribute;
+import org.opensaml.saml.saml2.metadata.RoleDescriptor;
+import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
+import org.opensaml.saml.saml2.metadata.SingleLogoutService;
 import org.wso2.carbon.identity.core.model.SAMLSSOServiceProviderDO;
 import org.wso2.carbon.identity.saml.common.util.SAMLInitializer;
 import org.wso2.carbon.identity.sp.metadata.saml2.exception.InvalidMetadataException;
@@ -206,7 +214,7 @@ public class Parser {
                 }
                 if (spssoDescriptor == null) {
                     throw new InvalidMetadataException(
-                            "No IDP Descriptors found, invalid file content."
+                            "No SP Descriptors found, invalid file content."
                     );
                 }
             } else {
@@ -214,7 +222,7 @@ public class Parser {
                     spssoDescriptor = (SPSSODescriptor) roleDescriptors.get(0);
                 } else {
                     throw new InvalidMetadataException(
-                            "No IDP Descriptors found, invalid file content."
+                            "No SP Descriptors found, invalid file content."
                     );
                 }
             }

--- a/components/org.wso2.carbon.identity.sp.metadata.saml2/src/main/java/org/wso2/carbon/identity/sp/metadata/saml2/util/Parser.java
+++ b/components/org.wso2.carbon.identity.sp.metadata.saml2/src/main/java/org/wso2/carbon/identity/sp/metadata/saml2/util/Parser.java
@@ -205,26 +205,16 @@ public class Parser {
                 throw new InvalidMetadataException("Role descriptor not found.");
             }
 
-            if (roleDescriptors.size() > 1) {
-                for (RoleDescriptor roleDescriptor : roleDescriptors) {
-                    if (roleDescriptor instanceof SPSSODescriptor) {
-                        spssoDescriptor = (SPSSODescriptor) roleDescriptor;
-                        break;
-                    }
+            for (RoleDescriptor roleDescriptor : roleDescriptors) {
+                if (roleDescriptor instanceof SPSSODescriptor) {
+                    spssoDescriptor = (SPSSODescriptor) roleDescriptor;
+                    break;
                 }
-                if (spssoDescriptor == null) {
-                    throw new InvalidMetadataException(
-                            "No SP Descriptors found, invalid file content."
-                    );
-                }
-            } else {
-                if (roleDescriptors.get(0) instanceof SPSSODescriptor) {
-                    spssoDescriptor = (SPSSODescriptor) roleDescriptors.get(0);
-                } else {
-                    throw new InvalidMetadataException(
-                            "No SP Descriptors found, invalid file content."
-                    );
-                }
+            }
+            if (spssoDescriptor == null) {
+                throw new InvalidMetadataException(
+                        "No SP Descriptors found, invalid file content."
+                );
             }
 
             this.setAssertionConsumerUrl(spssoDescriptor, samlssoServiceProviderDO);


### PR DESCRIPTION
### Proposed changes in this pull request

- Handle SP and IDP metadata when there are multiple role descriptors. Previous implementation picks only the first role descriptor for the process so there are situations where `ClassCastExceptions` occur.
- Add minor code cleanup for `SAML2SSOFederatedAuthenticatorConfigBuilder` and `Parser` classes.
- Fixes: https://github.com/wso2/product-is/issues/12292

### Follow up actions

- Upgrade the product-is to the released version (after this PR is merged).
