### PR TITLE
Handle SP and IDP metadata when there are multiple role descriptors

### DIFF
--- a/components/org.wso2.carbon.identity.idp.metadata.saml2/src/main/java/org/wso2/carbon/identity/idp/metadata/saml2/util/SAML2SSOFederatedAuthenticatorConfigBuilder.java
+++ b/components/org.wso2.carbon.identity.idp.metadata.saml2/src/main/java/org/wso2/carbon/identity/idp/metadata/saml2/util/SAML2SSOFederatedAuthenticatorConfigBuilder.java
@@ -62,16 +62,16 @@ public class SAML2SSOFederatedAuthenticatorConfigBuilder {
 
         if (entityDescriptor != null) {
             List<RoleDescriptor> roleDescriptors = entityDescriptor.getRoleDescriptors();
-            //assuming only one IDPSSO is inside the entitydescripter
+            // Assuming that only one IDPSSODescriptor is inside the EntityDescriptor.
             if (CollectionUtils.isNotEmpty(roleDescriptors)) {
-                RoleDescriptor roleDescriptor = roleDescriptors.get(0);
-                if (roleDescriptor != null) {
-                    IDPSSODescriptor idpssoDescriptor;
-                    try {
+                IDPSSODescriptor idpssoDescriptor = null;
+                for (RoleDescriptor roleDescriptor : roleDescriptors) {
+                    if (roleDescriptor instanceof IDPSSODescriptor) {
                         idpssoDescriptor = (IDPSSODescriptor) roleDescriptor;
-                    } catch (ClassCastException ex) {
-                        throw new IdentityApplicationManagementException("No IDP Descriptors found, invalid file content", ex);
+                        break;
                     }
+                }
+                if (idpssoDescriptor != null) {
                     Property properties[] = new Property[24];
 
                     Property property = new Property();
@@ -320,6 +320,8 @@ public class SAML2SSOFederatedAuthenticatorConfigBuilder {
                             }
                         }
                     }
+                } else {
+                    throw new IdentityApplicationManagementException("No IDP Descriptors found, invalid file content.");
                 }
             } else {
                 throw new IdentityApplicationManagementException("No Role Descriptors found, invalid file content");

--- a/components/org.wso2.carbon.identity.sp.metadata.saml2/src/main/java/org/wso2/carbon/identity/sp/metadata/saml2/util/Parser.java
+++ b/components/org.wso2.carbon.identity.sp.metadata.saml2/src/main/java/org/wso2/carbon/identity/sp/metadata/saml2/util/Parser.java
@@ -197,20 +197,21 @@ public class Parser {
         if (entityDescriptor != null) {
             this.setIssuer(entityDescriptor, samlssoServiceProviderDO);
             List<RoleDescriptor> roleDescriptors = entityDescriptor.getRoleDescriptors();
-            //TODO: handle when multiple role descriptors are available
-            //assuming only one SPSSO is inside the entitydescripter
-            RoleDescriptor roleDescriptor;
-            SPSSODescriptor spssoDescriptor;
+            // Assuming that only one SPSSODescriptor is inside the EntityDescriptor.
+            SPSSODescriptor spssoDescriptor = null;
 
             if (CollectionUtils.isEmpty(roleDescriptors)) {
                 throw new InvalidMetadataException("Role descriptor not found.");
             }
-            roleDescriptor = roleDescriptors.get(0);
-
-            if (!(roleDescriptor instanceof SPSSODescriptor)) {
+            for (RoleDescriptor roleDescriptor : roleDescriptors) {
+                if (roleDescriptor instanceof SPSSODescriptor) {
+                    spssoDescriptor = (SPSSODescriptor) roleDescriptor;
+                    break;
+                }
+            }
+            if (spssoDescriptor == null) {
                 throw new InvalidMetadataException("Invalid role descriptor class found.");
             }
-            spssoDescriptor = (SPSSODescriptor) roleDescriptor;
 
             this.setAssertionConsumerUrl(spssoDescriptor, samlssoServiceProviderDO);
             //Response Signing Algorithm - not found


### PR DESCRIPTION
### Proposed changes in this pull request

- Handle SP and IDP metadata when there are multiple role descriptors. Previous implementation picks only the first role descriptor for the process so there are situations where `ClassCastExceptions` occur.
- Fixes: https://github.com/wso2/product-is/issues/12292

### Follow up actions

- Upgrade the product-is to the released version (after this PR is merged).
