### PR TITLE
Fix adding multiple certificate for IDP

### DIFF
--- a/components/org.wso2.carbon.identity.idp.metadata.saml2/src/main/java/org/wso2/carbon/identity/idp/metadata/saml2/util/SAML2SSOFederatedAuthenticatorConfigBuilder.java
+++ b/components/org.wso2.carbon.identity.idp.metadata.saml2/src/main/java/org/wso2/carbon/identity/idp/metadata/saml2/util/SAML2SSOFederatedAuthenticatorConfigBuilder.java
@@ -41,6 +41,7 @@ import org.wso2.carbon.identity.application.common.util.IdentityApplicationConst
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
 
 /**
@@ -317,6 +318,7 @@ public class SAML2SSOFederatedAuthenticatorConfigBuilder {
                     federatedAuthenticatorConfig.setProperties(properties);
 
                     //set certificates
+                    StringBuilder certs = new StringBuilder();
                     if (CollectionUtils.isNotEmpty(descriptors)) {
                         for (KeyDescriptor descriptor : descriptors) {
                             if (descriptor != null) {
@@ -348,11 +350,7 @@ public class SAML2SSOFederatedAuthenticatorConfigBuilder {
                                                                                 get(k).getX509Certificates().get(y).
                                                                                 getValue();
 
-                                                                        builder.append(
-                                                                                org.apache.axiom.om.util.Base64.encode(
-                                                                                        cert.getBytes())
-                                                                        );
-                                                                        return federatedAuthenticatorConfig;
+                                                                        certs.append(cert);
                                                                     }
                                                                 }
                                                             }
@@ -370,6 +368,8 @@ public class SAML2SSOFederatedAuthenticatorConfigBuilder {
                             }
                         }
                     }
+                    builder.append(Base64.getEncoder().
+                            encodeToString(certs.toString().getBytes(StandardCharsets.UTF_8)));
                 } else {
                     throw new IdentityApplicationManagementException("No IDP Descriptors found, invalid file content.");
                 }


### PR DESCRIPTION
### Proposed changes in this pull request
# Description
One cause of this issue was due to breaking the signing certificate extraction after one certificate is found at [2] while processing the IdP SAML metadata. This will be resolved by returning the "federatedAuthenticatorConfig" after retrieving all the certificates

The other issue is appending each encoded certificate to the string builder when the time of retrieving and when it's decoded, it will give an incorrect value. Therefore with the fix, it will append all the certificates to the string builder first and finally, that will be decoded.
