### PR TITLE
Remove SHA1 default usage

### DIFF
--- a/components/org.wso2.carbon.identity.idp.metadata.saml2/src/main/java/org/wso2/carbon/identity/idp/metadata/saml2/MetadataCryptoProvider.java
+++ b/components/org.wso2.carbon.identity.idp.metadata.saml2/src/main/java/org/wso2/carbon/identity/idp/metadata/saml2/MetadataCryptoProvider.java
@@ -180,7 +180,7 @@ public class MetadataCryptoProvider implements CryptoProvider {
                 XMLObjectProviderRegistrySupport.getBuilderFactory().getBuilder(qname);
         Signature signature = builder.buildObject(qname);
         signature.setSigningCredential(credential);
-        signature.setSignatureAlgorithm(SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1);
+        signature.setSignatureAlgorithm(SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256);
         signature.setCanonicalizationAlgorithm(SignatureConstants.ALGO_ID_C14N_EXCL_OMIT_COMMENTS);
         baseDescriptor.setSignature(signature);
         return signature;

--- a/components/org.wso2.carbon.identity.idp.metadata.saml2/src/main/java/org/wso2/carbon/identity/idp/metadata/saml2/MetadataCryptoProvider.java
+++ b/components/org.wso2.carbon.identity.idp.metadata.saml2/src/main/java/org/wso2/carbon/identity/idp/metadata/saml2/MetadataCryptoProvider.java
@@ -18,7 +18,6 @@
 
 package org.wso2.carbon.identity.idp.metadata.saml2;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.xml.security.exceptions.XMLSecurityException;
@@ -183,13 +182,11 @@ public class MetadataCryptoProvider implements CryptoProvider {
         Signature signature = builder.buildObject(qname);
         signature.setSigningCredential(credential);
         String signatureAlgorithm;
-        if (StringUtils.isNotBlank(IdentityUtil.getProperty(IdentityConstants.ServerConfig
-                .SAML_METADATA_IDP_SIGNATURE_ALGO_URI))) {
-            signatureAlgorithm =
-                    IdentityUtil.getProperty(IdentityConstants.ServerConfig
-                            .SAML_METADATA_IDP_SIGNATURE_ALGO_URI).trim();
-        } else {
+        if (Boolean.parseBoolean(IdentityUtil.getProperty(IdentityConstants.ServerConfig
+                .SAML_METADATA_IDP_ENABLE_SHA256_ALGO))) {
             signatureAlgorithm = SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256;
+        } else {
+            signatureAlgorithm = SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1;
         }
         signature.setSignatureAlgorithm(signatureAlgorithm);
         signature.setCanonicalizationAlgorithm(SignatureConstants.ALGO_ID_C14N_EXCL_OMIT_COMMENTS);

--- a/components/org.wso2.carbon.identity.idp.metadata.saml2/src/main/java/org/wso2/carbon/identity/idp/metadata/saml2/MetadataCryptoProvider.java
+++ b/components/org.wso2.carbon.identity.idp.metadata.saml2/src/main/java/org/wso2/carbon/identity/idp/metadata/saml2/MetadataCryptoProvider.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.idp.metadata.saml2;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.xml.security.exceptions.XMLSecurityException;
@@ -36,6 +37,7 @@ import org.opensaml.xmlsec.signature.X509Certificate;
 import org.opensaml.xmlsec.signature.X509Data;
 import org.opensaml.xmlsec.signature.support.SignatureConstants;
 import org.w3c.dom.Document;
+import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.idp.metadata.saml2.util.BuilderUtil;
 import org.wso2.carbon.idp.mgt.MetadataException;
@@ -180,7 +182,16 @@ public class MetadataCryptoProvider implements CryptoProvider {
                 XMLObjectProviderRegistrySupport.getBuilderFactory().getBuilder(qname);
         Signature signature = builder.buildObject(qname);
         signature.setSigningCredential(credential);
-        signature.setSignatureAlgorithm(SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256);
+        String signatureAlgorithm;
+        if (StringUtils.isNotBlank(IdentityUtil.getProperty(IdentityConstants.ServerConfig
+                .SAML_METADATA_IDP_SIGNATURE_ALGO_URI))) {
+            signatureAlgorithm =
+                    IdentityUtil.getProperty(IdentityConstants.ServerConfig
+                            .SAML_METADATA_IDP_SIGNATURE_ALGO_URI).trim();
+        } else {
+            signatureAlgorithm = SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256;
+        }
+        signature.setSignatureAlgorithm(signatureAlgorithm);
         signature.setCanonicalizationAlgorithm(SignatureConstants.ALGO_ID_C14N_EXCL_OMIT_COMMENTS);
         baseDescriptor.setSignature(signature);
         return signature;

--- a/components/org.wso2.carbon.identity.sp.metadata.saml2/pom.xml
+++ b/components/org.wso2.carbon.identity.sp.metadata.saml2/pom.xml
@@ -138,6 +138,7 @@
                             org.opensaml.xmlsec.config,
                             org.wso2.carbon.identity.core.model;
                             version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.core.util;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.registry.core,
                             org.wso2.carbon.identity.saml.common.util.*; version="${saml.common.util.version.range}",
                         </Import-Package>

--- a/components/org.wso2.carbon.identity.sp.metadata.saml2/src/main/java/org/wso2/carbon/identity/sp/metadata/saml2/util/Parser.java
+++ b/components/org.wso2.carbon.identity.sp.metadata.saml2/src/main/java/org/wso2/carbon/identity/sp/metadata/saml2/util/Parser.java
@@ -20,7 +20,6 @@ package org.wso2.carbon.identity.sp.metadata.saml2.util;
 
 import net.shibboleth.utilities.java.support.xml.XMLParserException;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.opensaml.core.config.InitializationException;
@@ -189,12 +188,11 @@ public class Parser {
                                         SAMLSSOServiceProviderDO samlssoServiceProviderDO) {
 
         String signatureAlgorithm;
-        if (StringUtils.isNotBlank(IdentityUtil.getProperty(IdentityConstants.ServerConfig
-                .SAML_METADATA_SP_SIGNATURE_ALGO_URI))) {
-            signatureAlgorithm =
-                    IdentityUtil.getProperty(IdentityConstants.ServerConfig.SAML_METADATA_SP_SIGNATURE_ALGO_URI).trim();
-        } else {
+        if (Boolean.parseBoolean(IdentityUtil.getProperty(IdentityConstants.ServerConfig
+                .SAML_METADATA_SP_ENABLE_SHA256_ALGO))) {
             signatureAlgorithm = IdentityApplicationConstants.XML.SignatureAlgorithmURI.RSA_SHA256;
+        } else {
+            signatureAlgorithm = IdentityApplicationConstants.XML.SignatureAlgorithmURI.RSA_SHA1;
         }
         samlssoServiceProviderDO.setSigningAlgorithmUri(signatureAlgorithm);
     }
@@ -203,12 +201,11 @@ public class Parser {
                                        SAMLSSOServiceProviderDO samlssoServiceProviderDO) {
 
         String digestAlgorithm;
-        if (StringUtils.isNotBlank(IdentityUtil.getProperty(IdentityConstants.ServerConfig
-                .SAML_METADATA_SP_DIGEST_ALGO_URI))) {
-            digestAlgorithm =
-                    IdentityUtil.getProperty(IdentityConstants.ServerConfig.SAML_METADATA_SP_DIGEST_ALGO_URI).trim();
-        } else {
+        if (Boolean.parseBoolean(IdentityUtil.getProperty(IdentityConstants.ServerConfig
+                .SAML_METADATA_SP_ENABLE_SHA256_ALGO))) {
             digestAlgorithm = IdentityApplicationConstants.XML.DigestAlgorithmURI.SHA256;
+        } else {
+            digestAlgorithm = IdentityApplicationConstants.XML.DigestAlgorithmURI.SHA1;
         }
         samlssoServiceProviderDO.setDigestAlgorithmUri(digestAlgorithm);
     }

--- a/components/org.wso2.carbon.identity.sp.metadata.saml2/src/main/java/org/wso2/carbon/identity/sp/metadata/saml2/util/Parser.java
+++ b/components/org.wso2.carbon.identity.sp.metadata.saml2/src/main/java/org/wso2/carbon/identity/sp/metadata/saml2/util/Parser.java
@@ -184,13 +184,13 @@ public class Parser {
     private void setSigningAlgorithmUri(SPSSODescriptor spssoDescriptor,
                                         SAMLSSOServiceProviderDO samlssoServiceProviderDO) {
 
-        samlssoServiceProviderDO.setSigningAlgorithmUri("http://www.w3.org/2000/09/xmldsig#rsa-sha1");
+        samlssoServiceProviderDO.setSigningAlgorithmUri("http://www.w3.org/2001/04/xmldsig-more#rsa-sha256");
     }
 
     private void setDigestAlgorithmUri(SPSSODescriptor spssoDescriptor,
                                        SAMLSSOServiceProviderDO samlssoServiceProviderDO) {
 
-        samlssoServiceProviderDO.setDigestAlgorithmUri("http://www.w3.org/2000/09/xmldsig#sha1");
+        samlssoServiceProviderDO.setDigestAlgorithmUri("http://www.w3.org/2001/04/xmlenc#sha256");
     }
 
     private void setAttributeConsumingServiceIndex(SPSSODescriptor spssoDescriptor, SAMLSSOServiceProviderDO

--- a/components/org.wso2.carbon.identity.sp.metadata.saml2/src/main/java/org/wso2/carbon/identity/sp/metadata/saml2/util/Parser.java
+++ b/components/org.wso2.carbon.identity.sp.metadata.saml2/src/main/java/org/wso2/carbon/identity/sp/metadata/saml2/util/Parser.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.sp.metadata.saml2.util;
 
 import net.shibboleth.utilities.java.support.xml.XMLParserException;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.opensaml.core.config.InitializationException;
@@ -36,7 +37,10 @@ import org.opensaml.saml.saml2.metadata.RequestedAttribute;
 import org.opensaml.saml.saml2.metadata.RoleDescriptor;
 import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
 import org.opensaml.saml.saml2.metadata.SingleLogoutService;
+import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
+import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.core.model.SAMLSSOServiceProviderDO;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.saml.common.util.SAMLInitializer;
 import org.wso2.carbon.identity.sp.metadata.saml2.exception.InvalidMetadataException;
 import org.wso2.carbon.registry.core.Registry;
@@ -184,13 +188,29 @@ public class Parser {
     private void setSigningAlgorithmUri(SPSSODescriptor spssoDescriptor,
                                         SAMLSSOServiceProviderDO samlssoServiceProviderDO) {
 
-        samlssoServiceProviderDO.setSigningAlgorithmUri("http://www.w3.org/2001/04/xmldsig-more#rsa-sha256");
+        String signatureAlgorithm;
+        if (StringUtils.isNotBlank(IdentityUtil.getProperty(IdentityConstants.ServerConfig
+                .SAML_METADATA_SP_SIGNATURE_ALGO_URI))) {
+            signatureAlgorithm =
+                    IdentityUtil.getProperty(IdentityConstants.ServerConfig.SAML_METADATA_SP_SIGNATURE_ALGO_URI).trim();
+        } else {
+            signatureAlgorithm = IdentityApplicationConstants.XML.SignatureAlgorithmURI.RSA_SHA256;
+        }
+        samlssoServiceProviderDO.setSigningAlgorithmUri(signatureAlgorithm);
     }
 
     private void setDigestAlgorithmUri(SPSSODescriptor spssoDescriptor,
                                        SAMLSSOServiceProviderDO samlssoServiceProviderDO) {
 
-        samlssoServiceProviderDO.setDigestAlgorithmUri("http://www.w3.org/2001/04/xmlenc#sha256");
+        String digestAlgorithm;
+        if (StringUtils.isNotBlank(IdentityUtil.getProperty(IdentityConstants.ServerConfig
+                .SAML_METADATA_SP_DIGEST_ALGO_URI))) {
+            digestAlgorithm =
+                    IdentityUtil.getProperty(IdentityConstants.ServerConfig.SAML_METADATA_SP_DIGEST_ALGO_URI).trim();
+        } else {
+            digestAlgorithm = IdentityApplicationConstants.XML.DigestAlgorithmURI.SHA256;
+        }
+        samlssoServiceProviderDO.setDigestAlgorithmUri(digestAlgorithm);
     }
 
     private void setAttributeConsumingServiceIndex(SPSSODescriptor spssoDescriptor, SAMLSSOServiceProviderDO

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
     </dependencyManagement>
 
     <properties>
-        <org.wso2.carbon.identity.framework.version>5.25.163</org.wso2.carbon.identity.framework.version>
+        <org.wso2.carbon.identity.framework.version>5.25.210</org.wso2.carbon.identity.framework.version>
         <carbon.identity.package.import.version.range>[5.15.0, 7.0.0)</carbon.identity.package.import.version.range>
 
         <commons.collections.version>3.2.0.wso2v1</commons.collections.version>

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
     </dependencyManagement>
 
     <properties>
-        <org.wso2.carbon.identity.framework.version>5.16.56</org.wso2.carbon.identity.framework.version>
+        <org.wso2.carbon.identity.framework.version>5.25.163</org.wso2.carbon.identity.framework.version>
         <carbon.identity.package.import.version.range>[5.15.0, 7.0.0)</carbon.identity.package.import.version.range>
 
         <commons.collections.version>3.2.0.wso2v1</commons.collections.version>


### PR DESCRIPTION
## Purpose

The default behavior of our products uses SHA1 which is no longer considered as secure. This PR changes the default usage to SHA256 in the following flows.

- Metadata parsing for SAML SP
- Signing SAML IDP metadata

## Migration impact

New SPs created using an xml metadata file will have signing and digest algorithms set to SHA-256 algorithms (these algorithms are currently hard-coded). To revert this behaviour, use the following config.
```
[saml]
metadata.sp_enable_sha256_alg= false
```

Downloaded SAML IdP metadata will be signed with the new (hard-coded) algorithm. To revert this behaviour, use the following config.
```
[saml]
metadata.idp_enable_sha256_alg= false
```

## Related issues
 
- Issue https://github.com/wso2/product-is/issues/15793

## Related PRs

- PR https://github.com/wso2/carbon-identity-framework/pull/4567
- PR https://github.com/wso2-extensions/identity-outbound-auth-samlsso/pull/162
- PR https://github.com/wso2-extensions/identity-inbound-auth-sts/pull/136
- PR https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2076
- PR https://github.com/wso2/cipher-tool/pull/78
- PR https://github.com/wso2/carbon-kernel/pull/3574
- PR https://github.com/wso2-extensions/identity-user-account-association/pull/47
- PR https://github.com/wso2-enterprise/asgardeo-website/pull/639
- PR https://github.com/wso2-extensions/identity-governance/pull/707
- PR https://github.com/wso2-extensions/identity-inbound-auth-openid/pull/92
- PR https://github.com/wso2-extensions/identity-outbound-auth-sms-otp/pull/173
- PR https://github.com/wso2-extensions/identity-outbound-auth-email-otp/pull/157

## Documentation

- PR https://github.com/wso2/docs-is/pull/3717