### PR TITLE
Revert "Migrate security-mgt module from framework to its own group."

### DIFF
--- a/components/org.wso2.carbon.identity.idp.metadata.saml2/pom.xml
+++ b/components/org.wso2.carbon.identity.idp.metadata.saml2/pom.xml
@@ -71,7 +71,7 @@
             <artifactId>org.wso2.carbon.idp.mgt</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.security.mgt</groupId>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.security.mgt</artifactId>
             <exclusions>
                 <exclusion>
@@ -166,7 +166,7 @@
                             org.wso2.carbon.idp.mgt.util; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.registry.core.service;version="${carbon.kernel.registry.imp.pkg.version}",
                             org.wso2.carbon.registry.core.session;version="${carbon.kernel.registry.imp.pkg.version}",
-                            org.wso2.carbon.security.keystore;version="${carbon.security.mgt.version.range}",
+                            org.wso2.carbon.security.keystore;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.user.core.service; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.utils.multitenancy;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.registry.core; version="${carbon.kernel.registry.imp.pkg.version}",

--- a/components/org.wso2.carbon.identity.sp.metadata.saml2/pom.xml
+++ b/components/org.wso2.carbon.identity.sp.metadata.saml2/pom.xml
@@ -57,7 +57,7 @@
             <artifactId>org.wso2.carbon.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.security.mgt</groupId>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.security.mgt</artifactId>
             <exclusions>
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
     </dependencyManagement>
 
     <properties>
-        <org.wso2.carbon.identity.framework.version>5.25.210</org.wso2.carbon.identity.framework.version>
+        <org.wso2.carbon.identity.framework.version>5.25.305</org.wso2.carbon.identity.framework.version>
         <carbon.identity.package.import.version.range>[5.15.0, 7.0.0)</carbon.identity.package.import.version.range>
 
         <commons.collections.version>3.2.0.wso2v1</commons.collections.version>

--- a/pom.xml
+++ b/pom.xml
@@ -91,9 +91,9 @@
                 <version>${org.wso2.carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon.security.mgt</groupId>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.security.mgt</artifactId>
-                <version>${carbon.security.mgt.version}</version>
+                <version>${org.wso2.carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.metadata.saml2</groupId>
@@ -162,8 +162,6 @@
     <properties>
         <org.wso2.carbon.identity.framework.version>5.25.210</org.wso2.carbon.identity.framework.version>
         <carbon.identity.package.import.version.range>[5.15.0, 7.0.0)</carbon.identity.package.import.version.range>
-        <carbon.security.mgt.version.range>[1.0.0, 2.0.0)</carbon.security.mgt.version.range>
-        <carbon.security.mgt.version>1.0.0</carbon.security.mgt.version>
 
         <commons.collections.version>3.2.0.wso2v1</commons.collections.version>
         <httpcomponents-httpclient.wso2.version>4.3.6.wso2v2</httpcomponents-httpclient.wso2.version>
@@ -299,8 +297,8 @@
                 <inherited>true</inherited>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Reverts wso2-extensions/identity-metadata-saml2#86

Related issues:
- https://github.com/wso2/product-is/issues/16422