### PR TITLE
Remove the usages of deprecated KeyStoreAdmin constructor

### DIFF
--- a/components/org.wso2.carbon.identity.idp.metadata.saml2/src/main/java/org/wso2/carbon/identity/idp/metadata/saml2/SignKeyDataHolder.java
+++ b/components/org.wso2.carbon.identity.idp.metadata.saml2/src/main/java/org/wso2/carbon/identity/idp/metadata/saml2/SignKeyDataHolder.java
@@ -152,8 +152,7 @@ public class SignKeyDataHolder implements X509Credential {
             throw new MetadataException("Invalid file configurations. The key alias is not found.");
         }
 
-        KeyStoreAdmin keyAdmin = new KeyStoreAdmin(MultitenantConstants.SUPER_TENANT_ID,
-                IDPMetadataSAMLServiceComponentHolder.getInstance().getRegistryService().getGovernanceSystemRegistry());
+        KeyStoreAdmin keyAdmin = new KeyStoreAdmin(MultitenantConstants.SUPER_TENANT_ID);
         KeyStoreManager keyMan = KeyStoreManager.getInstance(MultitenantConstants.SUPER_TENANT_ID);
         issuerPrivateKey = (PrivateKey) keyAdmin.getPrivateKey(keyAlias, true);
 

--- a/components/org.wso2.carbon.identity.idp.metadata.saml2/src/main/java/org/wso2/carbon/identity/idp/metadata/saml2/SignKeyDataHolder.java
+++ b/components/org.wso2.carbon.identity.idp.metadata.saml2/src/main/java/org/wso2/carbon/identity/idp/metadata/saml2/SignKeyDataHolder.java
@@ -29,7 +29,6 @@ import org.opensaml.security.x509.X509Credential;
 import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.core.util.KeyStoreManager;
-import org.wso2.carbon.identity.idp.metadata.saml2.internal.IDPMetadataSAMLServiceComponentHolder;
 import org.wso2.carbon.idp.mgt.MetadataException;
 import org.wso2.carbon.security.keystore.KeyStoreAdmin;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
@@ -51,6 +50,7 @@ import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Collection;
+
 import javax.crypto.SecretKey;
 
 /**
@@ -152,8 +152,7 @@ public class SignKeyDataHolder implements X509Credential {
             throw new MetadataException("Invalid file configurations. The key alias is not found.");
         }
 
-        KeyStoreAdmin keyAdmin = new KeyStoreAdmin(MultitenantConstants.SUPER_TENANT_ID,
-                IDPMetadataSAMLServiceComponentHolder.getInstance().getRegistryService().getGovernanceSystemRegistry());
+        KeyStoreAdmin keyAdmin = new KeyStoreAdmin(MultitenantConstants.SUPER_TENANT_ID);
         KeyStoreManager keyMan = KeyStoreManager.getInstance(MultitenantConstants.SUPER_TENANT_ID);
         issuerPrivateKey = (PrivateKey) keyAdmin.getPrivateKey(keyAlias, true);
 

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
     </dependencyManagement>
 
     <properties>
-        <org.wso2.carbon.identity.framework.version>5.25.305</org.wso2.carbon.identity.framework.version>
+        <org.wso2.carbon.identity.framework.version>7.7.269</org.wso2.carbon.identity.framework.version>
         <carbon.identity.package.import.version.range>[5.15.0, 8.0.0)</carbon.identity.package.import.version.range>
 
         <commons.collections.version>3.2.0.wso2v1</commons.collections.version>


### PR DESCRIPTION
### Proposed changes in this pull request

$subject

Part of: https://github.com/wso2/product-is/issues/21206
Related PR: https://github.com/wso2/carbon-identity-framework/pull/6525